### PR TITLE
Changed endpoint to match latest Twilio.

### DIFF
--- a/Services/Twilio/Rest/SmsMessages.php
+++ b/Services/Twilio/Rest/SmsMessages.php
@@ -4,7 +4,7 @@ class Services_Twilio_Rest_SmsMessages
     extends Services_Twilio_ListResource
 {
     public function __construct($client, $uri) {
-        $uri = preg_replace("#SmsMessages#", "SMS/Messages", $uri);
+        $uri = preg_replace("#SmsMessages#", "Messages", $uri);
         parent::__construct($client, $uri);
     }
 


### PR DESCRIPTION
Changed endpoint to match latest Twilio. This fixes errors with messages over 160 characters.