### PR TITLE
Allow other modules to modify the SMS before sending

### DIFF
--- a/org_civicrm_sms_twilio.php
+++ b/org_civicrm_sms_twilio.php
@@ -160,6 +160,19 @@ class org_civicrm_sms_twilio extends CRM_SMS_Provider {
       }
 
       try {
+        /*
+         * Allow other modules to modify the SMS before sending
+         */
+        CRM_Utils_Hook::singleton()->invoke(
+          ['header', 'from', 'message'],
+          $header,
+          $from,
+          $message,
+          CRM_Utils_Hook::$_nullObject,
+          CRM_Utils_Hook::$_nullObject,
+          CRM_Utils_Hook::$_nullObject,
+          'civicrm_twilio_alterSMS');
+
         $twilioMessage = $this->_twilioClient->messages->create(
           $header['To'],
           array(


### PR DESCRIPTION
Do this by defining and invoking a CiviCRM hook with signature hook_civicrm_twilio_alterSMS(&$header, &$from, &$message)